### PR TITLE
build: Use gtk4-update-icon-cache

### DIFF
--- a/build-aux/meson/postinstall.py
+++ b/build-aux/meson/postinstall.py
@@ -10,7 +10,7 @@ destdir = environ.get('DESTDIR', '')
 # Package managers set this so we don't need to run
 if not destdir:
     print('Updating icon cache...')
-    call(['gtk-update-icon-cache', '-qtf', path.join(datadir, 'icons', 'hicolor')])
+    call(['gtk4-update-icon-cache', '-qtf', path.join(datadir, 'icons', 'hicolor')])
 
     print('Updating desktop database...')
     call(['update-desktop-database', '-q', path.join(datadir, 'applications')])


### PR DESCRIPTION
Otherwise the postinstall script will fail if GTK3 is not installed.

We can also use [`gnome.post_install()`](https://mesonbuild.com/Gnome-module.html#gnomepost_install) if we require meson 0.59.0.