### PR TITLE
Add shorttitle needed for the Chicago Manual of Style

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -50,6 +50,7 @@ field_dict = {
     "author": "Author",
     "editor": "Editor",
     "title": "Title",
+    "shorttitle" : "Short Title", # This is needed for the Chicago Manual of Style.
     "journal": "Journal",
     "booktitle": "Book Title",
     "chapter": "Chapter",

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -50,7 +50,7 @@ field_dict = {
     "author": "Author",
     "editor": "Editor",
     "title": "Title",
-    "shorttitle" : "Short Title", # This is needed for the Chicago Manual of Style.
+    "shorttitle": "Short Title",  # This is needed for the Chicago Manual of Style.
     "journal": "Journal",
     "booktitle": "Book Title",
     "chapter": "Chapter",


### PR DESCRIPTION
- This is needed for Pandoc Citeproc to process.
- ideally we can consider turning the field_dict into a file that users can customize.